### PR TITLE
Automatic deployment to ShinyApps

### DIFF
--- a/.github/workflows/shinyapps_deploy.yml
+++ b/.github/workflows/shinyapps_deploy.yml
@@ -15,7 +15,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
  
-     steps:
       - name: Install System Dependencies
         run: |
           sudo apt-get update

--- a/.github/workflows/shinyapps_deploy.yml
+++ b/.github/workflows/shinyapps_deploy.yml
@@ -35,7 +35,7 @@ jobs:
           options(repos = c(REPO_NAME = "https://packagemanager.rstudio.com/all/__linux__/focal/latest", 
              getOption("repos")))
           install.packages(c("assertthat", "attempt", "config", "dockerfiler", "golem", 
-             "markdown", "parsedate", "rematch", "rhub", "uuid", "rsconnect", "devtools"))
+             "markdown", "parsedate", "rematch", "rhub", "uuid", "rsconnect", "devtools", "wesanderson"))
           devtools::install_github("Sage-Bionetworks/projectlive.modules")
         shell: Rscript {0}
 

--- a/.github/workflows/shinyapps_deploy.yml
+++ b/.github/workflows/shinyapps_deploy.yml
@@ -13,6 +13,10 @@ on:
 jobs:
   shiny-deploy:
     runs-on: ubuntu-latest
+     env:
+      # This should not be necessary for installing from public repo's however install_github() fails without it.
+      GITHUB_PAT: ${{ secrets.REPO_PAT }}
+ 
     steps:
  
       - name: Install System Dependencies
@@ -22,16 +26,12 @@ jobs:
  
       - uses: actions/checkout@v2
 
-#      - uses: r-lib/actions/setup-pandoc@v1
-
-#      - uses: r-lib/actions/setup-r@v1
-#        with:
-#          use-public-rspm: true
-
-#      - uses: r-lib/actions/setup-renv@v1
-
       - name: Install R packages
         run: |
+          # The binary package distributions from R Studio dramatically speed up installation time
+          # For Ubuntu 18.04 (Bionic) it's https://packagemanager.rstudio.com/all/__linux__/bionic/latest
+          # For Ubuntu 20.04 (Focal)  it's https://packagemanager.rstudio.com/all/__linux__/focal/latest 
+          options(repos = c(REPO_NAME = "https://packagemanager.rstudio.com/all/__linux__/bionic/latest", getOption("repos")))
           install.packages(c("rsconnect", "devtools"))
           devtools::install_github("Sage-Bionetworks/projectlive.modules")
         shell: Rscript {0}

--- a/.github/workflows/shinyapps_deploy.yml
+++ b/.github/workflows/shinyapps_deploy.yml
@@ -48,10 +48,6 @@ jobs:
           devtools::install_github("Sage-Bionetworks/projectlive.modules")
         shell: Rscript {0}
 
-      - name: Ensure executability in venv
-        shell: bash
-        run: chmod -R +x "${{ env.VENV_NAME }}"
-  
       - name: Authorize and deploy app
         run: |
           branch<-Sys.getenv("GITHUB_REF_NAME")

--- a/.github/workflows/shinyapps_deploy.yml
+++ b/.github/workflows/shinyapps_deploy.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   shiny-deploy:
     runs-on: ubuntu-latest
-     env:
+    env:
       # This should not be necessary for installing from public repo's however install_github() fails without it.
       GITHUB_PAT: ${{ secrets.REPO_PAT }}
  

--- a/.github/workflows/shinyapps_deploy.yml
+++ b/.github/workflows/shinyapps_deploy.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Install Python Dependencies
         shell: bash
         run: |
-          source "${{ env.CONDA_ENV_NAME }}"/bin/activate
+          source "${{ env.VENV_NAME }}"/bin/activate
           pip3 install synapseclient
         
       - name: Install R packages

--- a/.github/workflows/shinyapps_deploy.yml
+++ b/.github/workflows/shinyapps_deploy.yml
@@ -24,7 +24,6 @@ jobs:
       - name: Install System Dependencies
         run: |
           sudo apt-get update
-          # need libicui18n
           sudo apt-get install -y pip python3.8-venv libcurl4-openssl-dev
  
       - uses: actions/checkout@v2
@@ -36,11 +35,15 @@ jobs:
           chmod 755 "${{ env.VENV_NAME }}"/bin/activate
           source "${{ env.VENV_NAME }}"/bin/activate
         
+      - name: Install Python Dependencies
+        shell: bash
+        run: |
+          source "${{ env.CONDA_ENV_NAME }}"/bin/activate
+          pip3 install synapseclient
+        
       - name: Install R packages
         run: |
           # The binary package distributions from R Studio dramatically speed up installation time
-          # For Ubuntu 18.04 (Bionic) it's https://packagemanager.rstudio.com/all/__linux__/bionic/latest
-          # For Ubuntu 20.04 (Focal)  it's https://packagemanager.rstudio.com/all/__linux__/focal/latest 
           options(repos = c(REPO_NAME = "https://packagemanager.rstudio.com/all/__linux__/focal/latest", 
              getOption("repos")))
           install.packages(c("assertthat", "attempt", "config", "dockerfiler", "golem", 

--- a/.github/workflows/shinyapps_deploy.yml
+++ b/.github/workflows/shinyapps_deploy.yml
@@ -30,8 +30,10 @@ jobs:
 
 #      - uses: r-lib/actions/setup-renv@v1
 
-      - name: Install rsconnect
-        run: install.packages("rsconnect")
+      - name: Install R packages
+        run: |
+          install.packages(c("rsconnect", "devtools"))
+          devtools::install_github("Sage-Bionetworks/projectlive.modules")
         shell: Rscript {0}
 
       - name: Authorize and deploy app

--- a/.github/workflows/shinyapps_deploy.yml
+++ b/.github/workflows/shinyapps_deploy.yml
@@ -23,7 +23,7 @@ jobs:
         run: |
           sudo apt-get update
           # need libicui18n
-          sudo apt-get install -y libcurl4-openssl-dev libicu-dev
+          sudo apt-get install -y libcurl4-openssl-dev
  
       - uses: actions/checkout@v2
 
@@ -32,8 +32,10 @@ jobs:
           # The binary package distributions from R Studio dramatically speed up installation time
           # For Ubuntu 18.04 (Bionic) it's https://packagemanager.rstudio.com/all/__linux__/bionic/latest
           # For Ubuntu 20.04 (Focal)  it's https://packagemanager.rstudio.com/all/__linux__/focal/latest 
-          options(repos = c(REPO_NAME = "https://packagemanager.rstudio.com/all/__linux__/focal/latest", getOption("repos")))
-          install.packages(c("rsconnect", "devtools"))
+          options(repos = c(REPO_NAME = "https://packagemanager.rstudio.com/all/__linux__/focal/latest", 
+             getOption("repos")))
+          install.packages(c("assertthat", "attempt", "config", "dockerfiler", "golem", 
+             "markdown", "parsedate", "rematch", "rhub", "uuid", "rsconnect", "devtools"))
           devtools::install_github("Sage-Bionetworks/projectlive.modules")
         shell: Rscript {0}
 

--- a/.github/workflows/shinyapps_deploy.yml
+++ b/.github/workflows/shinyapps_deploy.yml
@@ -32,9 +32,9 @@ jobs:
       - name: Create and Activate Python Virtual Environment
         shell: bash
         run: |
-          python3 -m venv "${{ env.CONDA_ENV_NAME }}"
-          chmod 755 "${{ env.CONDA_ENV_NAME }}"/bin/activate
-          source "${{ env.CONDA_ENV_NAME }}"/bin/activate
+          python3 -m venv "${{ env.VENV_NAME }}"
+          chmod 755 "${{ env.VENV_NAME }}"/bin/activate
+          source "${{ env.VENV_NAME }}"/bin/activate
         
       - name: Install R packages
         run: |

--- a/.github/workflows/shinyapps_deploy.yml
+++ b/.github/workflows/shinyapps_deploy.yml
@@ -14,6 +14,8 @@ jobs:
   shiny-deploy:
     runs-on: ubuntu-latest
     env:
+      # Note, this name is referred to in 'global.R'
+      VENV_NAME: virtual_env
       # This should not be necessary for installing from public repo's however install_github() fails without it.
       GITHUB_PAT: ${{ secrets.REPO_PAT }}
  
@@ -23,10 +25,17 @@ jobs:
         run: |
           sudo apt-get update
           # need libicui18n
-          sudo apt-get install -y libcurl4-openssl-dev
+          sudo apt-get install -y pip python3.8-venv libcurl4-openssl-dev
  
       - uses: actions/checkout@v2
 
+      - name: Create and Activate Python Virtual Environment
+        shell: bash
+        run: |
+          python3 -m venv "${{ env.CONDA_ENV_NAME }}"
+          chmod 755 "${{ env.CONDA_ENV_NAME }}"/bin/activate
+          source "${{ env.CONDA_ENV_NAME }}"/bin/activate
+        
       - name: Install R packages
         run: |
           # The binary package distributions from R Studio dramatically speed up installation time

--- a/.github/workflows/shinyapps_deploy.yml
+++ b/.github/workflows/shinyapps_deploy.yml
@@ -47,6 +47,19 @@ jobs:
           if (!startsWith(branch, "release")) {
              appName = paste(appName, "staging", sep="-")
           }
+ 
+          # create config file
+          config <- "CLIENT_ID: ${{ secrets.OAUTH_CLIENT_ID }}"
+          config <- c(config, "CLIENT_SECRET: ${{ secrets.OAUTH_CLIENT_SECRET }}")
+          appUrl<- sprintf("https://%s.shinyapps.io/%s", rsConnectUser, appName)
+          config <- c(config, sprintf("APP_URL: %s", appUrl))
+         
+          configFileConn<-file("oauth_config.yaml")
+          tryCatch(
+             writeLines(config, configFileConn),
+             finally=close(configFileConn)
+          )
+ 
           rsconnect::setAccountInfo("${{ secrets.RSCONNECT_USER }}", "${{ secrets.RSCONNECT_TOKEN }}", "${{ secrets.RSCONNECT_SECRET }}")
           rsconnect::deployApp(appName = appName)
         shell: Rscript {0}

--- a/.github/workflows/shinyapps_deploy.yml
+++ b/.github/workflows/shinyapps_deploy.yml
@@ -48,6 +48,10 @@ jobs:
           devtools::install_github("Sage-Bionetworks/projectlive.modules")
         shell: Rscript {0}
 
+      - name: Ensure executability in venv
+        shell: bash
+        run: chmod -R +x "${{ env.VENV_NAME }}"
+  
       - name: Authorize and deploy app
         run: |
           branch<-Sys.getenv("GITHUB_REF_NAME")

--- a/.github/workflows/shinyapps_deploy.yml
+++ b/.github/workflows/shinyapps_deploy.yml
@@ -1,0 +1,41 @@
+# Workflow derived from https://github.com/r-lib/actions/tree/master/examples
+# Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
+
+name: shiny-deploy
+
+on:
+  push:
+    branches:
+      - master
+      - release*
+
+jobs:
+  shiny-deploy:
+    runs-on: ubuntu-latest
+    steps:
+ 
+      - uses: actions/checkout@v2
+
+      - uses: r-lib/actions/setup-pandoc@v1
+
+      - uses: r-lib/actions/setup-r@v1
+        with:
+          use-public-rspm: true
+
+      - uses: r-lib/actions/setup-renv@v1
+
+      - name: Install rsconnect
+        run: install.packages("rsconnect")
+        shell: Rscript {0}
+
+      - name: Authorize and deploy app
+        run: |
+          branch<-Sys.getenv("GITHUB_REF_NAME")
+          repo<-Sys.getenv("GITHUB_REPOSITORY")
+          appName<-strsplit(repo, "/")[[1]][2]
+          if (!startsWith(branch, "release")) {
+             appName = paste(appName, "staging", sep="-")
+          }
+          rsconnect::setAccountInfo("${{ secrets.RSCONNECT_USER }}", "${{ secrets.RSCONNECT_TOKEN }}", "${{ secrets.RSCONNECT_SECRET }}")
+          rsconnect::deployApp(appName = appName)
+        shell: Rscript {0}

--- a/.github/workflows/shinyapps_deploy.yml
+++ b/.github/workflows/shinyapps_deploy.yml
@@ -47,6 +47,9 @@ jobs:
           if (!startsWith(branch, "release")) {
              appName = paste(appName, "staging", sep="-")
           }
+          rsConnectUser <-"${{ secrets.RSCONNECT_USER }}"
+          rsConnectToken <- "${{ secrets.RSCONNECT_TOKEN }}"
+          rsConnectSecret <- "${{ secrets.RSCONNECT_SECRET }}"
  
           # create config file
           config <- "CLIENT_ID: ${{ secrets.OAUTH_CLIENT_ID }}"
@@ -60,6 +63,6 @@ jobs:
              finally=close(configFileConn)
           )
  
-          rsconnect::setAccountInfo("${{ secrets.RSCONNECT_USER }}", "${{ secrets.RSCONNECT_TOKEN }}", "${{ secrets.RSCONNECT_SECRET }}")
+          rsconnect::setAccountInfo(rsConnectUser, rsConnectToken, rsConnectSecret)
           rsconnect::deployApp(appName = appName)
         shell: Rscript {0}

--- a/.github/workflows/shinyapps_deploy.yml
+++ b/.github/workflows/shinyapps_deploy.yml
@@ -6,6 +6,7 @@ name: shiny-deploy
 on:
   push:
     branches:
+      - IT-828
       - master
       - release*
 

--- a/.github/workflows/shinyapps_deploy.yml
+++ b/.github/workflows/shinyapps_deploy.yml
@@ -32,7 +32,7 @@ jobs:
           # For Ubuntu 18.04 (Bionic) it's https://packagemanager.rstudio.com/all/__linux__/bionic/latest
           # For Ubuntu 20.04 (Focal)  it's https://packagemanager.rstudio.com/all/__linux__/focal/latest 
           options(repos = c(REPO_NAME = "https://packagemanager.rstudio.com/all/__linux__/bionic/latest", getOption("repos")))
-          install.packages(c("rsconnect", "devtools"))
+          install.packages(c("rvest", "rsconnect", "devtools"))
           devtools::install_github("Sage-Bionetworks/projectlive.modules")
         shell: Rscript {0}
 

--- a/.github/workflows/shinyapps_deploy.yml
+++ b/.github/workflows/shinyapps_deploy.yml
@@ -15,15 +15,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
  
+     steps:
+      - name: Install System Dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libcurl4-openssl-dev
+ 
       - uses: actions/checkout@v2
 
-      - uses: r-lib/actions/setup-pandoc@v1
+#      - uses: r-lib/actions/setup-pandoc@v1
 
-      - uses: r-lib/actions/setup-r@v1
-        with:
-          use-public-rspm: true
+#      - uses: r-lib/actions/setup-r@v1
+#        with:
+#          use-public-rspm: true
 
-      - uses: r-lib/actions/setup-renv@v1
+#      - uses: r-lib/actions/setup-renv@v1
 
       - name: Install rsconnect
         run: install.packages("rsconnect")

--- a/.github/workflows/shinyapps_deploy.yml
+++ b/.github/workflows/shinyapps_deploy.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Install System Dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y libcurl4-openssl-dev
+          sudo apt-get install -y libcurl4-openssl-dev libicu-dev
  
       - uses: actions/checkout@v2
 
@@ -32,7 +32,7 @@ jobs:
           # For Ubuntu 18.04 (Bionic) it's https://packagemanager.rstudio.com/all/__linux__/bionic/latest
           # For Ubuntu 20.04 (Focal)  it's https://packagemanager.rstudio.com/all/__linux__/focal/latest 
           options(repos = c(REPO_NAME = "https://packagemanager.rstudio.com/all/__linux__/bionic/latest", getOption("repos")))
-          install.packages(c("rvest", "rsconnect", "devtools"))
+          install.packages(c("rsconnect", "devtools"))
           devtools::install_github("Sage-Bionetworks/projectlive.modules")
         shell: Rscript {0}
 

--- a/.github/workflows/shinyapps_deploy.yml
+++ b/.github/workflows/shinyapps_deploy.yml
@@ -22,6 +22,7 @@ jobs:
       - name: Install System Dependencies
         run: |
           sudo apt-get update
+          # need libicui18n
           sudo apt-get install -y libcurl4-openssl-dev libicu-dev
  
       - uses: actions/checkout@v2
@@ -31,7 +32,7 @@ jobs:
           # The binary package distributions from R Studio dramatically speed up installation time
           # For Ubuntu 18.04 (Bionic) it's https://packagemanager.rstudio.com/all/__linux__/bionic/latest
           # For Ubuntu 20.04 (Focal)  it's https://packagemanager.rstudio.com/all/__linux__/focal/latest 
-          options(repos = c(REPO_NAME = "https://packagemanager.rstudio.com/all/__linux__/bionic/latest", getOption("repos")))
+          options(repos = c(REPO_NAME = "https://packagemanager.rstudio.com/all/__linux__/focal/latest", getOption("repos")))
           install.packages(c("rsconnect", "devtools"))
           devtools::install_github("Sage-Bionetworks/projectlive.modules")
         shell: Rscript {0}

--- a/.github/workflows/shinyapps_deploy.yml
+++ b/.github/workflows/shinyapps_deploy.yml
@@ -52,10 +52,10 @@ jobs:
           rsConnectSecret <- "${{ secrets.RSCONNECT_SECRET }}"
  
           # create config file
-          config <- "CLIENT_ID: ${{ secrets.OAUTH_CLIENT_ID }}"
-          config <- c(config, "CLIENT_SECRET: ${{ secrets.OAUTH_CLIENT_SECRET }}")
+          config <- "client_id: ${{ secrets.OAUTH_CLIENT_ID }}"
+          config <- c(config, "client_secret: ${{ secrets.OAUTH_CLIENT_SECRET }}")
           appUrl<- sprintf("https://%s.shinyapps.io/%s", rsConnectUser, appName)
-          config <- c(config, sprintf("APP_URL: %s", appUrl))
+          config <- c(config, sprintf("app_url: %s", appUrl))
          
           configFileConn<-file("oauth_config.yaml")
           tryCatch(

--- a/R/global.R
+++ b/R/global.R
@@ -2,4 +2,4 @@ if (interactive()) {
   options(shiny.port = 8100)
 } 
 
-OAUTH_LIST <- projectlive.modules::create_oauth_list()
+OAUTH_LIST <- projectlive.modules::create_oauth_list("oauth_config.yaml")

--- a/R/global.R
+++ b/R/global.R
@@ -1,3 +1,10 @@
+
+# Activate virtual env
+Sys.unsetenv("RETICULATE_PYTHON")
+# Note, the name of the virtual environment is defined in the GH Actions workflow
+reticulate::use_virtualenv(file.path(getwd(),"virtual_env"))
+
+
 if (interactive()) {
   options(shiny.port = 8100)
 } 

--- a/R/global.R
+++ b/R/global.R
@@ -2,7 +2,11 @@
 # Activate virtual env
 Sys.unsetenv("RETICULATE_PYTHON")
 # Note, the name of the virtual environment is defined in the GH Actions workflow
-reticulate::use_virtualenv(file.path(getwd(),"virtual_env"))
+venv_name<-"virtual_env"
+reticulate::use_virtualenv(file.path(getwd(),venv_name))
+# We get a '126' error (non-executable) if we don't do this:
+system(sprintf("chmod -R +x %s", venv_name))
+
 
 
 if (interactive()) {


### PR DESCRIPTION
This PR adds a workflow to deploy to ShinyApps. Work in progress is deployed to /projectLive_NF-staging. When a release* branch is created the app will be deployed to /projectLive_NF. This allows us to develop and test while the production version continues to run.

Before merging the PR, set the following parameters in the projectLive_NF GitHub repo' (under Settings > Secrets > New repository secret):

REPO_PAT: This is a GitHub personal access token having (at least) 'repository' scope.
RSCONNECT_USER: sagebio
RSCONNECT_TOKEN: See the token in the shinyapps.io record in LastPass.
RSCONNECT_SECRET: See the secret in the shinyapps.io record in LastPass.
OAUTH_CLIENT_ID: Use 100133 or create your own.
OAUTH_CLIENT_SECRET: If you use 100133, retrieve the secret from the ShinyApps Synapse account record in LastPass.