### PR TITLE
route master branch (and staging site) to dev backend files

### DIFF
--- a/R/app_server.R
+++ b/R/app_server.R
@@ -18,7 +18,7 @@ app_server <- shinyServer(function(input, output, session) {
     id = "synapse_module",
     syn = syn,
     config = shiny::reactive(
-      jsonlite::read_json("inst/synapse_module.json")
+      jsonlite::read_json("inst/dev_synapse_module.json")
     )
   )
 


### PR DESCRIPTION
The staging site pulls from master branch. To test changes in backend data_files, we want to route it to `dev` files folder instead of `live` folder on Synapse. 

So changing the config to use `synapse_module.json` to `dev_synapse_module.json`

Reminder: 
Before a release, change config back to `synapse_module.json`. Will add this to Readme.

closes #198