### PR TITLE
Update studyId create_rds_files.R

### DIFF
--- a/create_rds_files/create_rds_files.R
+++ b/create_rds_files/create_rds_files.R
@@ -19,7 +19,7 @@ store_file_in_synapse <- function(syn, file, parent_id){
 
 
 # studies ----
-studies <- get_synapse_tbl(syn, "syn16787123")
+studies <- get_synapse_tbl(syn, "syn52694652")
 saveRDS(studies, "studies.RDS")
 
 store_file_in_synapse(


### PR DESCRIPTION
This should fix the broken job. We updated the Studies table to a materialized view, so **production is syn52694652** while syn16787123 definitely only stores the long text now.  